### PR TITLE
feat(postgress): configure the PostgreSQL connector to consume Neon DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Is important to mention that is required to logout when changing from Cloud to L
 Is important to mention that is required to logout when changing from Cloud to Local, and vice versa.
 
 1. Type `npm run start:local`.
-2. Follow the instructions to log-in with your local Docker, it should looks like something like this: `stepzen login --config C:/Users/YourUser/.stepzen/stepzen-config.local.yaml`
+2. Follow the instructions to log-in with your local Docker, it should looks like something like this: `stepzen login --config ~/.stepzen/stepzen-config.local.yaml`
 3. Type `npm run start` and 🚀!
 
 ## Useful Commands
@@ -55,4 +55,14 @@ docker run \
 
 ```sh
 docker push bhuma/stepzen-ahanaio-prestodb --all-tags
+```
+
+
+# Run Ahana / Presto locally
+
+```bash
+docker run -it \
+  -p 8080:8080 \
+  -v connectors/postgresql.properties:/opt/presto-server/etc/catalog/postgresql.properties \
+  ahanaio/prestodb-sandbox
 ```

--- a/connectors/postgresql.properties
+++ b/connectors/postgresql.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://<HOST_NAME>:5432/<DATABASE_NAME>
+connection-user=<USERNAME>
+connection-password=<PASSWORD>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "git+https://github.com/bhuma-dev/stepzen-ahanaio-cloud-service.git"
   },
   "scripts": {
-    "start": "cd ./stepzen && stepzen login --account yuzhne --adminkey ${STEPZEN_ADMIN_KEY} && stepzen start --dashboard=local",
+    "start": "cd ./stepzen && stepzen start --dashboard=local",
+    "start:cloud": "cd ./stepzen && stepzen login --account yuzhne --adminkey ${STEPZEN_ADMIN_KEY} && stepzen start --dashboard=local",
     "start:local": "cd ./stepzen && stepzen service start",
     "stop": "stepzen service stop"
   },

--- a/stepzen/config.yaml
+++ b/stepzen/config.yaml
@@ -3,4 +3,9 @@ configurationset:
       name: presto_config
       dsn: https://admin@prestodb.develop.bhuma.dev?catalog=tpch&schema=sf1
       # Use this configuration to run local
-      # dsn: 'http://admin@host.docker.internal:8080?catalog=tpch&schema=sf1'
+      # dsn: http://admin@host.docker.internal:8080?catalog=tpch&schema=sf1
+  - configuration:
+      name: presto_config_postgresql
+      dsn: https://admin@prestodb.develop.bhuma.dev?catalog=postgresql&schema=public
+      # Use this configuration to run local
+      # dsn: http://admin@host.docker.internal:8080?catalog=postgresql&schema=public

--- a/stepzen/index.graphql
+++ b/stepzen/index.graphql
@@ -1,3 +1,75 @@
+type Assets {
+	asset_id: Int
+	asset_name: String
+	asset_type: String
+	asset_location: String
+	asset_purchase_date: Date
+	asset_purchase_price: Float
+	asset_current_usage: Float
+	asset_discovery_status: String
+	asset_discovery_date: Date
+	asset_discovery_completion_date: Date
+	asset_compliance_status: String
+	asset_risk_level: String
+	asset_encryption: String
+	asset_patch_availability: String
+	asset_allowance: String
+}
+
+extend type Query {
+  asset(asset_id: Int!): Assets
+    @dbquery(type: "presto", table: "assets", configuration: "presto_config_postgresql")
+}
+
+input AssetFilter {
+  asset_id: IntFilter
+  asset_name: StringFilter
+  asset_type: StringFilter
+  asset_location: StringFilter
+}
+
+extend type Query {
+  assets(filter: AssetFilter): [Assets]
+    @dbquery(type: "presto", table: "assets", configuration: "presto_config_postgresql")
+}
+
+# AssetAge
+
+type  AssetAge {
+  total_assets: Int 
+  asset_age: Int
+}
+
+input AssetAgeFilter {
+  total_assets: IntFilter
+  asset_age: IntFilter
+}
+
+extend type Query {
+  AssetsAge(filter: AssetAgeFilter): [AssetAge]
+    @dbquery(type: "presto", table: "asset_age", configuration: "presto_config_postgresql")
+}
+
+# AssetByRiskLevelWithPercentage
+
+type  AssetByRiskLevelWithPercentage {
+  asset_risk_level: String
+  assets_count: Int
+  percentage: Float
+}
+
+input AssetByRiskLevelWithPercentageFilter {
+  asset_risk_level: StringFilter
+  assets_count: IntFilter
+  percentage: FloatFilter
+}
+
+extend type Query {
+  AssetsByRiskLevelWithPercentage(filter: AssetByRiskLevelWithPercentageFilter): [AssetByRiskLevelWithPercentage]
+    @dbquery(type: "presto", table: "asset_by_risk_level_with_percentage", configuration: "presto_config_postgresql")
+}
+
+
 type Customer {
   custkey: Int
   name: String
@@ -22,11 +94,18 @@ input IntFilter {
   gt: Int
 }
 
+input FloatFilter {
+  eq: Float
+  lt: Float
+  gt: Float
+}
+
 input StringFilter {
   eq: String
   lt: String
   gt: String
 }
+
 input CustomerFilter {
   custkey: IntFilter
   name: StringFilter


### PR DESCRIPTION
# [PostgreSQL Connector](https://prestodb.io/docs/current/connector/postgresql.html)

The PostgreSQL connector allows querying and creating tables in an external PostgreSQL database. This can be used to join data between different systems like PostgreSQL and Hive, or between two different PostgreSQL instances.

Configuration[#](https://prestodb.io/docs/current/connector/postgresql.html#configuration)
To configure the PostgreSQL connector, create a catalog properties file in etc/catalog named, for example, postgresql.properties, to mount the PostgreSQL connector as the postgresql catalog. Create the file with the following contents, replacing the connection properties as appropriate for your setup:

```
connector.name=postgresql
connection-url=jdbc:postgresql://example.net:5432/database
connection-user=root
connection-password=secret
```